### PR TITLE
REL1_34 compatibility

### DIFF
--- a/includes/CopyWatchers.php
+++ b/includes/CopyWatchers.php
@@ -123,7 +123,7 @@ class CopyWatchers extends ParserFunctionHelper {
 	static function getPageWatchers ($ns, $title) {
 
 		// code adapted from Extension:WhoIsWatching
-		$dbr = wfGetDB( DB_SLAVE );
+		$dbr = wfGetDB( DB_REPLICA );
 		$watchingUserIDs = array();
 
 


### PR DESCRIPTION
The constant DB_SLAVE, deprecated in 1.28, has been removed. Use DB_REPLICA.

If you want backwards compatibility for MediaWiki < 1.28 add in 
		// Backward compatibility for MW < 1.28.
		if ( !defined( 'DB_REPLICA' ) ) {
			define( 'DB_REPLICA', DB_SLAVE );
		}